### PR TITLE
icmp_policy => 'safe' not in correct format for iptables v1.4.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,22 +54,22 @@ class iptables (
     'ACCEPT'  => 'ACCEPT',
     default   => 'DROP',
   }
- 
+
   $real_icmp_policy = $icmp_policy ? {
     'drop'    => '-j DROP',
     'DROP'    => '-j DROP',
-    'safe'    => '-m icmp --icmp-type ! echo-request -j ACCEPT',
+    'safe'    => '-m icmp ! --icmp-type echo-request -j ACCEPT',
     'accept'  => '-j ACCEPT',
     'ACCEPT'  => '-j ACCEPT',
     default   => '-j ACCEPT',
   }
- 
+
   $real_output_policy = $output_policy ? {
     'drop'    => 'drop',
     'DROP'    => 'drop',
     default   => 'accept',
   }
- 
+
   $real_log = $log ? {
     'all'     => 'all',
     'dropped' => 'drop',
@@ -101,9 +101,9 @@ class iptables (
     'no'      => 'no',
     default   => 'drop',
   }
- 
+
   $real_safe_ssh = any2bool($safe_ssh)
- 
+
   $real_broadcast_policy = $broadcast_policy ? {
     'drop'    => 'drop',
     'DROP'    => 'drop',


### PR DESCRIPTION
This is a pull request for this issue: https://github.com/example42/puppet-iptables/issues/10

The rule was changed, because it was in a format that iptables 1.4.x does not seem to support.  It has been tested and applies cleanly on both ubuntu 12.04 (iptables v1.4.12 and centos 5.6 iptables iptables v1.3.5.
