### PR TITLE
Add support for PREROUTING and POSTROUTING chains

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -66,9 +66,11 @@ define iptables::rule (
   $true_order = $order ? {
     ''    => $table ? {
       'filter' => $chain ? {
-         'INPUT'   => '15',
-         'OUTPUT'  => '25',
-         'FORWARD' => '35',
+         'INPUT'        => '15',
+         'OUTPUT'       => '25',
+         'FORWARD'      => '35',
+         'PREROUTING'   => '45',
+         'POSTROUTING'  => '55',
       },
       'nat'    => '50',
       'mangle' => '70',


### PR DESCRIPTION
If you need to define a rule into PREROUTING or POSTROUTING chain, e.g.:

```
iptables::rule { 'redirect-80-to-8000':
    command => '-A',
    chain => 'PREROUTING',
    target => 'REDIRECT',
    rule => '-p tcp --dport 80 --to-port 8000'
}
```

it will end up in this error message:

```
Error: No matching value for selector param 'PREROUTING'
at /tmp/vagrant-puppet/modules-0/iptables/manifests/rule.pp:72 on node web-server
```
