### PR TITLE
Remove concat's deprecated setup call

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,8 @@ fixtures:
     "monitor": "git://github.com/example42/puppet-monitor.git"
     "firewall": "git://github.com/example42/puppet-firewall.git"
     "iptables": "git://github.com/example42/puppet-iptables.git"
-    "concat": "git://github.com/example42/puppet-concat.git"
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "concat": "git://github.com/puppetlabs/puppetlabs-concat.git"
   symlinks:
     "iptables": "#{source_dir}"
 

--- a/Modulefile
+++ b/Modulefile
@@ -8,5 +8,6 @@ source 'https://github.com/example42/puppet-iptables'
 summary 'Puppet module for foo'
 description 'This module installs and manages iptables. Check README.rdoc for details. Puppi is required for some common functions: you can install them without using the whole module. '
 dependency 'example42/puppi', '>=2.0.0'
-dependency 'ripienaar/concat', '>=0.0.1'
+dependency 'puppetlabs/stdlib', '>=4.1.0'
+dependency 'puppetlabs/concat', '>=1.0.0'
 

--- a/manifests/concat_emitter.pp
+++ b/manifests/concat_emitter.pp
@@ -14,7 +14,6 @@ define iptables::concat_emitter(
 ) {
 
   include iptables
-  include concat::setup
   
   $real_icmp_port = $is_ipv6 ? {
     true    => '-p icmpv6',

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -54,7 +54,6 @@ define iptables::rule (
   $debug          = false ) {
 
   include iptables
-  include concat::setup
 
   # IPv6 enabled rules prerequisites IPv6 enabled iptables also
   # TODO: To enable this feature, we first have to unchain the circular dependency firewall -> iptables


### PR DESCRIPTION
Ciao Alessandro,

  The `concat::setup` call is deprecated, this patch removes it. 
