### PR TITLE
concat: added force

### DIFF
--- a/manifests/concat_emitter.pp
+++ b/manifests/concat_emitter.pp
@@ -25,6 +25,7 @@ define iptables::concat_emitter(
     owner   => $iptables::config_file_owner,
     group   => $iptables::config_file_group,
     notify  => Service['iptables'],
+    force   => true,
   }
 
 


### PR DESCRIPTION
Because of a potential bug in puppetlabs-concat force is needed here. See https://github.com/puppetlabs/puppetlabs-concat/commit/00a8f4e73695eb93529942b31d0580df17ee9393#diff-4050c10d82ce9debdbe92764ddf021e4R101 for the comment on that bug.
