### PR TITLE
Remove unused $general_base_source/$::base_source

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -146,16 +146,4 @@ class iptables::params  {
   $mangle_footer_template         = 'iptables/concat/mangle_footer'
   $rules                          = {}
 
-  ## FILE SERVING SOURCE
-  case $::base_source {
-    '': {
-      $general_base_source = $::puppetversion ? {
-        /(^0.25)/ => 'puppet:///modules',
-        /(^0.)/   => "puppet://${servername}",
-        default   => 'puppet:///modules',
-      }
-    }
-    default: { $general_base_source = $::base_source }
-  }
-
 }


### PR DESCRIPTION
This also fixes an strict_variables error:
Undefined variable "::base_source"; Undefined variable "base_source" at .../modules/iptables/manifests/params.pp:149
