### PR TITLE
Support IPv6 NAT table on recent kernels

### DIFF
--- a/manifests/concat_emitter.pp
+++ b/manifests/concat_emitter.pp
@@ -101,7 +101,9 @@ define iptables::concat_emitter(
     notify  => $::iptables::manage_service_autorestart,
   }
 
-  if !$is_ipv6 {
+  # The NAT table is not supported for IPv6 until kernel 3.8
+  # Only load the header when running at least that kernel
+  if !$is_ipv6 or (versioncmp($kernelmajversion, 3.8) >= 0) {
     # The NAT table header with the default policies
     concat::fragment{ "iptables_nat_header_${name}":
       target  => $emitter_target,
@@ -118,8 +120,6 @@ define iptables::concat_emitter(
       notify  => $::iptables::manage_service_autorestart,
     }
   }
-
-
 
   # The MANGLE table header with the default policies
   concat::fragment{ "iptables_mangle_header_${name}":


### PR DESCRIPTION
This commit adds support for the IPv6 NAT table on Linux 3.8 and up,
using the $kernelmajversion fact. As far as I know this is omnipresent.

Without this commit, behaviour is:
* If a user creates nat-table ipv6 rules through this module, on an
  older kernel, the file will not load as those rules are not valid
  for the filter table. User ends up with no v6 firewall loaded at all.
* If no nat-table rules are created, things work just fine.

With this commit, behaviour is:
* If a user creates nat-table ipv6 rules through this module,
  - on kernel >= 3.8, the nat rules will be applied
  - on an older kernel, the file will not load as the rules are not valid
    for the filter table. User ends up with no v6 firewall loaded at all.
* If no nat-table rules are created,
  - on kernel >= 3.8, an empty nat table header is inserted in the rules,
    and things work just fine.
  - on an older kernel, things work just fine.

Closes #73.